### PR TITLE
Abstract für Keynote hinzufügen

### DIFF
--- a/lit-2016/talks.txt
+++ b/lit-2016/talks.txt
@@ -9,16 +9,41 @@ klaenge   thalmayr    lynx          ??? ???
 === keynote
 
 Katharina Nocun
-Eröffnungsvortrag
-Eröffnungsvortrag
+Free as Free Software
+Free as Free Software
 
-<em>Der Inhalt wird noch bekanntgegeben.</em>
+Viel zu selten wird darüber gesprochen, warum Freie Software die Welt 
+retten kann. Warum es nach Snowden umso wichtiger ist, sich in dieser 
+starken Gemeinschaft einzubringen. Und warum wir den großen Konzernen 
+nicht die kritische Infrastruktur der vernetzten Zukunft überlassen 
+dürfen.
+
+Wissenschaft steht immer auf den Schultern von Giganten. Wann haben wir 
+zuletzt darüber nachgedacht, wie die Geschichte wohl verlaufen wäre, 
+wenn  Tim Berners-Lee das Internet-Protokoll nicht der Welt geschenkt 
+hätte? Und wenn das Mailprotokoll kein offener Standard, sondern im 
+Besitz eines Konzerns wäre? Vieles, was wir als selbstverständlich 
+hinnehmen, ist tatsächlich die mutige Entscheidung Einzelner gewesen, 
+die an die Idee von offenen Standards und Freier Software als 
+Katalysator für gesellschaftliche Veränderung glauben. Es gibt keinen 
+Grund für falsche Bescheidenheit: Die Geschichte gibt ihnen recht. Sie 
+haben die Welt verändert. Deshalb: Wir brauchen mehr davon.
+
+Während andere aus finanziellen Gründen Patent- und 
+Standardisierungskriege anzetteln, arbeiten wir an einem kompatiblen 
+alternativen Ökosystem. Ein Ökosystem, das den Nutzern wieder die 
+Kontrolle über die Technik zurück gibt, die Einzug nimmt in immer mehr 
+Bereiche unseres Lebens. Diese Bewegung kann aus Kooperation nur 
+gewinnen. Kooperation unter einander. Aber auch mit gesellschaftlichen 
+Akteuren. Viel zu selten wird darüber gesprochen, warum Freie Software
+auch ein politisches Werkzeug ist.
 
 <a href="https://de.wikipedia.org/wiki/Katharina_Nocun">Katharina Nocun</a> ist
 eine deutsch-polnische Politikerin, Netzaktivistin und Bloggerin. Sie war von
 Mai bis November 2013 politische Geschäftsführerin der Piratenpartei
 Deutschland und leitete bei Campact e.V. unter anderem die Kampagne
-&bdquo;Schutz für Edward Snowden in Deutschland&ldquo;.
+&bdquo;Schutz für Edward Snowden in Deutschland&ldquo;. Seit März arbeitet sie
+als Campaignerin für Wikimedia Deutschland.
 
 
 === sniffing


### PR DESCRIPTION
Dieser Commit fügt den Abstract für Katharina Nocuns Keynote hinzu und ergänzt in ihrer Vita, dass sie mittlerweile für Wikimedia arbeitet.
