### PR TITLE
Gnublin2 in Titel hinzufügen

### DIFF
--- a/lit-2016/talks.txt
+++ b/lit-2016/talks.txt
@@ -593,7 +593,7 @@ vorgestellt.
 === hunz
 
 Benedikt &bdquo;Hunz&ldquo; Heinz
-Offene Hardware für offene Software
+Offene Hardware für offene Software (Gnublin2)
 Offene Hardware für offene Software (Gnublin2)
 
 Wer kennt den Raspberry Pi noch nicht? Für circa 30&nbsp;&euro; bekommt man einen


### PR DESCRIPTION
War expliziter Wunsch, dass das Wort Gnublin2 im Titel auftaucht.
